### PR TITLE
Change to depend on imu_tools

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -17,7 +17,7 @@
   <build_depend>roslint</build_depend>
   <build_depend>std_srvs</build_depend>
 
-  <run_depend>imu_filter_madgwick</run_depend>
+  <run_depend>imu_tools</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>rqt_plot</run_depend>
   <run_depend>rviz</run_depend>

--- a/package.xml
+++ b/package.xml
@@ -17,7 +17,8 @@
   <build_depend>roslint</build_depend>
   <build_depend>std_srvs</build_depend>
 
-  <run_depend>imu_tools</run_depend>
+  <run_depend>imu_filter_madgwick</run_depend>
+  <run_depend>rviz_imu_plugin</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>rqt_plot</run_depend>
   <run_depend>rviz</run_depend>


### PR DESCRIPTION
- We got error in rviz if rviz_imu_plugin not installed
- It's better to depend on imu_tools meta-package